### PR TITLE
Fix prompt mapping to retain saved metadata

### DIFF
--- a/PromptBar/Models/Prompt.swift
+++ b/PromptBar/Models/Prompt.swift
@@ -19,12 +19,20 @@ struct Prompt: Identifiable, Equatable, Codable {
     var analysisDescription: String?
     
     init(
-        id: UUID = UUID(),
+        id: UUID,
         title: String,
         content: String,
-        description: String? = nil,
-        tags: [Tag] = [],
-        isFavorite: Bool = false
+        description: String?,
+        tags: [Tag],
+        isFavorite: Bool,
+        createdAt: Date,
+        modifiedAt: Date,
+        usedCount: Int,
+        lastUsedAt: Date?,
+        category: String?,
+        analysisStatus: AnalysisStatus,
+        analysisConfidence: Double?,
+        analysisDescription: String?
     ) {
         self.id = id
         self.title = title
@@ -32,16 +40,40 @@ struct Prompt: Identifiable, Equatable, Codable {
         self.description = description
         self.tags = tags
         self.isFavorite = isFavorite
-        self.createdAt = Date()
-        self.modifiedAt = Date()
-        self.usedCount = 0
-        self.lastUsedAt = nil
-        
-        // Initialize analysis fields
-        self.category = nil
-        self.analysisStatus = .pending
-        self.analysisConfidence = nil
-        self.analysisDescription = nil
+        self.createdAt = createdAt
+        self.modifiedAt = modifiedAt
+        self.usedCount = usedCount
+        self.lastUsedAt = lastUsedAt
+        self.category = category
+        self.analysisStatus = analysisStatus
+        self.analysisConfidence = analysisConfidence
+        self.analysisDescription = analysisDescription
+    }
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        content: String,
+        description: String? = nil,
+        tags: [Tag] = [],
+        isFavorite: Bool = false
+    ) {
+        self.init(
+            id: id,
+            title: title,
+            content: content,
+            description: description,
+            tags: tags,
+            isFavorite: isFavorite,
+            createdAt: Date(),
+            modifiedAt: Date(),
+            usedCount: 0,
+            lastUsedAt: nil,
+            category: nil,
+            analysisStatus: .pending,
+            analysisConfidence: nil,
+            analysisDescription: nil
+        )
     }
 }
 

--- a/PromptBar/Repositories/PromptRepository.swift
+++ b/PromptBar/Repositories/PromptRepository.swift
@@ -226,22 +226,29 @@ final class SQLitePromptRepository: PromptRepository {
         let analysisStatus = AnalysisStatus(rawValue: analysisStatusString) ?? .pending
         let analysisConfidence = row["analysis_confidence"] as? Double
         let analysisDescription = row["analysis_description"] as? String
-        
-        var prompt = Prompt(
+
+        // Map timestamp fields
+        let createdAtTime = (row["created_at"] as? Double) ?? (row["created_at"] as? Int64).map(Double.init) ?? Date().timeIntervalSince1970
+        let modifiedAtTime = (row["modified_at"] as? Double) ?? (row["modified_at"] as? Int64).map(Double.init) ?? createdAtTime
+        let lastUsedTime = (row["last_used_at"] as? Double) ?? (row["last_used_at"] as? Int64).map(Double.init)
+
+        let prompt = Prompt(
             id: id,
             title: title,
             content: content,
             description: description,
             tags: [], // TODO: Load tags separately
-            isFavorite: isFavorite
+            isFavorite: isFavorite,
+            createdAt: Date(timeIntervalSince1970: createdAtTime),
+            modifiedAt: Date(timeIntervalSince1970: modifiedAtTime),
+            usedCount: Int((row["used_count"] as? Int64) ?? 0),
+            lastUsedAt: lastUsedTime.map { Date(timeIntervalSince1970: $0) },
+            category: category,
+            analysisStatus: analysisStatus,
+            analysisConfidence: analysisConfidence,
+            analysisDescription: analysisDescription
         )
-        
-        // Set analysis properties
-        prompt.category = category
-        prompt.analysisStatus = analysisStatus
-        prompt.analysisConfidence = analysisConfidence
-        prompt.analysisDescription = analysisDescription
-        
+
         return prompt
     }
     


### PR DESCRIPTION
## Summary
- add initializer to `Prompt` that accepts persisted metadata like timestamps and usage counts
- map all persisted fields in `SQLitePromptRepository.mapRowToPrompt` so fetched prompts reflect stored values

## Testing
- `swiftc -c PromptBar/Repositories/PromptRepository.swift` *(fails: no such module 'SQLite3')*
- `swift - <<'EOF' ... EOF`

------
https://chatgpt.com/codex/tasks/task_e_68956cca96d88329af6f39fc1468c775