### PR TITLE
Fix missing onChange parameter in MainView

### DIFF
--- a/PromptBar/MainView.swift
+++ b/PromptBar/MainView.swift
@@ -29,7 +29,7 @@ struct MainView: View {
         .onAppear {
             isSearchFocused = true
         }
-        .onChange(of: searchText) {
+        .onChange(of: searchText) { _ in
             withAnimation(Theme.Animation.quick) {
                 isSearching = !searchText.isEmpty
             }


### PR DESCRIPTION
## Summary
- handle onChange with explicit parameter to avoid compile error

## Testing
- `swiftc PromptBar/MainView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_689571ddaba4832986a2c3300c6393f6